### PR TITLE
fix: button injection on persistent 4chan XT quick reply

### DIFF
--- a/src/js/content.js
+++ b/src/js/content.js
@@ -452,12 +452,12 @@ function getFields(element) {
       callback(element);
     }
 
-    const match = element.querySelector(selector);
+    const matches = element.querySelectorAll(selector);
 
-    if (match) {
+    matches.forEach((match) => {
       debugLog(debugMsg, match);
       callback(match);
-    }
+    });
   });
 }
 


### PR DESCRIPTION
4chan XT is an actively maintained fork of 4chan X that uses TypeScript instead of CoffeeScript, along with other improvements. It appears that XT is able to inject the persistent quick reply fast enough that it is available at the document.body scan, therefore not triggering a mutation event.

Since it currently uses querySelector, it only hits the original post form and not the injected one. Changing this to a querySelectorAll with a forEach solves the problem. I have quickly tested a few different scenarios (native extension, 4X/4XT persistent, 4X/4XT not persistent) and have not run into any problems with, for example, duplicating the injection or anything else that you may expect a forEach to cause in some circumstances.